### PR TITLE
fix: CR-4273 Change tool name

### DIFF
--- a/.cursor/rules/baz-codebase-exploration.mdc
+++ b/.cursor/rules/baz-codebase-exploration.mdc
@@ -1,5 +1,5 @@
 ---
-description: Baz codebase exploration — use indexed grep, file-glob, and cross-repo search via Baz MCP. Use `gh` / `glab` only to read specific files once you know the path.
+description: Baz codebase exploration — use indexed grep, file-glob, and repo-summary search via Baz MCP. Use `gh` / `glab` only to read specific files once you know the path.
 alwaysApply: true
 ---
 
@@ -17,7 +17,7 @@ This rule applies when planning a feature against repos that are not cloned loca
 
 | Job | Tool |
 |---|---|
-| Find which repos are involved | `cross_repo_search` (Baz) |
+| Find which repos are involved | `repo_search` (Baz) |
 | Find code by symbol / regex inside a repo | `remote_grep` (Baz) |
 | Find files by name / glob inside a repo | `remote_file_search` (Baz) |
 | Read a specific file you already know the path of | `gh api repos/<owner>/<repo>/contents/<path>` |
@@ -33,15 +33,15 @@ This rule applies when planning a feature against repos that are not cloned loca
 
 ### Step 1: Orient (once)
 
-If the user has not told you which repo(s) to look in, call `cross_repo_search` **exactly once** with broad keywords:
+If the user has not told you which repo(s) to look in, call `repo_search` **exactly once** with broad keywords:
 
 ```text
-cross_repo_search(keywords: ["<topic>", "<topic synonym>"], domains?: ["API", "BUSINESS_LOGIC", ...])
+repo_search(keywords: ["<topic>", "<topic synonym>"], domains?: ["API", "BUSINESS_LOGIC", ...])
 ```
 
 Read the returned `{repoId, repoName, domain, summary}` entries and pick the most likely repos using your own judgement (results are not LLM-ranked).
 
-**If the result is empty or too large**, do **not** re-call `cross_repo_search` with rephrased keywords. Instead:
+**If the result is empty or too large**, do **not** re-call `repo_search` with rephrased keywords. Instead:
 - For empty: pick a likely repo by name and skip to Step 2.
 - For too-large (`exceeds maximum allowed tokens`): re-call **once** with a `domains` filter to narrow scope.
 
@@ -89,5 +89,5 @@ Based on what you found, propose:
 ## Things to avoid
 
 - Do **not** ask the user to clone repos for you.
-- Do **not** re-query `cross_repo_search` with rephrased keywords. One call, then pick a repo.
+- Do **not** re-query `repo_search` with rephrased keywords. One call, then pick a repo.
 - Do **not** run `remote_file_search` and `gh` tree-listing for the same directory.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Baz Plugin
 
-The Baz plugin adds three indexed search tools to your agent — `cross_repo_search`, `remote_grep`, and `remote_file_search` — and a skill that routes searches through Baz while keeping reads on `gh` / `glab`.
+The Baz plugin adds three indexed search tools to your agent — `repo_search`, `remote_grep`, and `remote_file_search` — and a skill that routes searches through Baz while keeping reads on `gh` / `glab`.
 
 Designed for planning features against repositories you haven't checked out locally. Indexed search across the whole org, no clone, no rate limits.
 
@@ -42,7 +42,7 @@ Cursor doesn't auto-install MCP servers. Two manual steps:
 
 ## What you get
 
-- **`cross_repo_search(keywords, domains?)`** — semantic search across architecture summaries of every repo in your org. No `gh` equivalent.
+- **`repo_search(keywords, domains?)`** — semantic search across indexed architecture summaries. Works across every repo in your org, and across the per-domain summaries of a single large monorepo. No `gh` equivalent.
 - **`remote_grep(repository, pattern, path)`** — indexed regex grep inside one repo, scoped to a path. ~2 lines of context per match.
 - **`remote_file_search(repository, pattern)`** — glob file-name search inside one repo. Useful when you have a naming hunch but not the exact path.
 

--- a/skills/baz-codebase-exploration/SKILL.md
+++ b/skills/baz-codebase-exploration/SKILL.md
@@ -24,7 +24,7 @@ This skill helps you plan a feature against repos the user has not cloned locall
 
 | Job | Tool |
 |---|---|
-| Find which repos are involved | `cross_repo_search` (Baz) |
+| Find which repos are involved | `repo_search` (Baz) |
 | Find code by symbol / regex inside a repo | `remote_grep` (Baz) |
 | Find files by name / glob inside a repo | `remote_file_search` (Baz) |
 | Read a specific file you already know the path of | `gh api repos/<owner>/<repo>/contents/<path>` |
@@ -40,15 +40,15 @@ This skill helps you plan a feature against repos the user has not cloned locall
 
 ### Step 1: Orient (once)
 
-If the user has not told you which repo(s) to look in, call `cross_repo_search` **exactly once** with broad keywords:
+If the user has not told you which repo(s) to look in, call `repo_search` **exactly once** with broad keywords:
 
 ```text
-cross_repo_search(keywords: ["<topic>", "<topic synonym>"], domains?: ["API", "BUSINESS_LOGIC", ...])
+repo_search(keywords: ["<topic>", "<topic synonym>"], domains?: ["API", "BUSINESS_LOGIC", ...])
 ```
 
 Read the returned `{repoId, repoName, domain, summary}` entries and pick the most likely repos using your own judgement (results are not LLM-ranked).
 
-**If the result is empty or too large**, do **not** re-call `cross_repo_search` with rephrased keywords. Instead:
+**If the result is empty or too large**, do **not** re-call `repo_search` with rephrased keywords. Instead:
 - For empty: pick a likely repo by name and skip to Step 2.
 - For too-large (`exceeds maximum allowed tokens`): re-call **once** with a `domains` filter to narrow scope.
 
@@ -96,5 +96,5 @@ Based on what you found, propose:
 ## Things to avoid
 
 - Do **not** ask the user to clone repos for you.
-- Do **not** re-query `cross_repo_search` with rephrased keywords. One call, then pick a repo.
+- Do **not** re-query `repo_search` with rephrased keywords. One call, then pick a repo.
 - Do **not** run `remote_file_search` and `gh` tree-listing for the same directory.


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Rename the Baz plugin’s repo discovery helper in the README, skill guide, and exploration rule so the guidance reflects <code>repo_search</code> as the entry point for identifying repos. Clarify the orientation steps so Baz exploration flows instruct callers to rely on <code>repo_search</code> once before narrowing scope with domains.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>yardenmintz@gmail.com</td><td>Change tool name</td><td>June 22, 2026</td></tr></table></details>
<sub><a href="https://main.baz.ninja/changes/baz-scm/baz-plugin/3?tool=ast">Review this PR on Baz</a> | <a href="https://main.baz.ninja/agents/baz">Customize your next review</a></sub>