### PR TITLE
fix: update plugin.json URLs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,7 +12,7 @@
   "mcpServers": {
     "baz": {
       "type": "http",
-      "url": "https://mcp.baz.co/mcp",
+      "url": "https://baz.co/mcp",
       "headers": {
         "x-session-id": "${CLAUDE_SESSION_ID}"
       }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -14,7 +14,7 @@
   "mcpServers": {
     "baz": {
       "type": "http",
-      "url": "https://mcp.baz.co/mcp",
+      "url": "https://baz.co/mcp",
       "env_http_headers": {
         "x-session-id": "CODEX_SESSION_ID"
       }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -15,7 +15,7 @@
   "mcpServers": {
     "baz": {
       "type": "http",
-      "url": "https://mcp.baz.co/mcp",
+      "url": "https://baz.co/mcp",
       "headers": {
         "x-session-id": "${env:CURSOR_SESSION_ID}"
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,4 +39,4 @@ skills/baz-codebase-exploration/SKILL.md   Skill injected into context on instal
 
 ## MCP server
 
-All three platforms wire `https://mcp.baz.co/mcp` as an HTTP MCP server named `baz`. OAuth (Descope) opens on first use.
+All three platforms wire `https://baz.co/mcp` as an HTTP MCP server named `baz`. OAuth (Descope) opens on first use.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Designed for planning features against repositories you haven't checked out loca
 ### Claude Code
 
 ```bash
-/plugin install baz-scm/baz-plugin@main
+/plugin marketplace add baz-scm/baz-plugin
+/plugin add baz
+/reload-plugins
 ```
 
-Claude Code reads `.claude-plugin/plugin.json`, loads `skills/baz-codebase-exploration/SKILL.md`, and registers the Baz MCP server. First time you use a Baz tool, your browser opens for OAuth (Descope) — log in with your Baz account.
+Claude Code reads `.claude-plugin/marketplace.json`, `.claude-plugin/plugin.json`, loads `skills/baz-codebase-exploration/SKILL.md`, and registers the Baz MCP server and hook. First time you use a Baz tool, your browser opens for OAuth (Descope) — log in with your Baz account.
 
 ### OpenAI Codex CLI
 
@@ -33,7 +35,7 @@ Cursor doesn't auto-install MCP servers. Two manual steps:
      "mcpServers": {
        "baz": {
          "type": "http",
-         "url": "https://mcp.baz.co/mcp"
+         "url": "https://baz.co/mcp"
        }
      }
    }


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the Baz MCP server configurations in Claude, Codex, and Cursor so every flow points at <code>https://baz.co/mcp</code> before OAuth is triggered for the shared Baz account. Clarify that Claude Code now reads <code>marketplace.json</code> alongside <code>plugin.json</code> when registering the Baz MCP server and hook after installing the plugin from the marketplace.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/baz-plugin/5?tool=ast&topic=Marketplace+install+doc>Marketplace install doc</a>
        </td><td>Document the marketplace-based installation flow so Claude Code reads <code>marketplace.json</code> in addition to <code>plugin.json</code> when registering the Baz MCP server and hook after adding the plugin.<details><summary>Modified files (1)</summary><ul><li>README.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrod@baz.co</td><td>fix: update plugin.jso...</td><td>June 22, 2026</td></tr>
<tr><td>yardenmintz@gmail.com</td><td>fix: Change tool name ...</td><td>June 22, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/baz-plugin/5?tool=ast&topic=Unified+MCP+URL>Unified MCP URL</a>
        </td><td>Redirect the Baz MCP server references in the Claude, Codex, and Cursor plugin configurations plus the MCP docs to <code>https://baz.co/mcp</code>, keeping all flows wired to the unified endpoint before OAuth at first use.<details><summary>Modified files (5)</summary><ul><li>.claude-plugin/plugin.json</li>
<li>.codex-plugin/plugin.json</li>
<li>.cursor-plugin/plugin.json</li>
<li>CLAUDE.md</li>
<li>README.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrod@baz.co</td><td>fix: update plugin.jso...</td><td>June 22, 2026</td></tr>
<tr><td>yardenmintz@gmail.com</td><td>fix: Change tool name ...</td><td>June 22, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/baz-scm/baz-plugin/5?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>