### PR TITLE
fix: Remove bad mcp headers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -12,10 +12,7 @@
   "mcpServers": {
     "baz": {
       "type": "http",
-      "url": "https://baz.co/mcp",
-      "headers": {
-        "x-session-id": "${CLAUDE_SESSION_ID}"
-      }
+      "url": "https://baz.co/mcp"
     }
   }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -14,10 +14,7 @@
   "mcpServers": {
     "baz": {
       "type": "http",
-      "url": "https://baz.co/mcp",
-      "env_http_headers": {
-        "x-session-id": "CODEX_SESSION_ID"
-      }
+      "url": "https://baz.co/mcp"
     }
   },
   "interface": {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -15,10 +15,7 @@
   "mcpServers": {
     "baz": {
       "type": "http",
-      "url": "https://baz.co/mcp",
-      "headers": {
-        "x-session-id": "${env:CURSOR_SESSION_ID}"
-      }
+      "url": "https://baz.co/mcp"
     }
   }
 }


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Remove stale header injection from the Claude, Codex, and Cursor plugin configs so the MCP endpoints only declare the URL. Ensure the Codex interface continues to reference Baz MCP without redundant header definitions.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrod@baz.co</td><td>fix: Remove bad mcp he...</td><td>June 23, 2026</td></tr>
<tr><td>internal-baz-ci-app[bot]</td><td>chore(main): release 0...</td><td>June 22, 2026</td></tr></table></details>
<sub><a href="https://main.baz.ninja/changes/baz-scm/baz-plugin/6?tool=ast">Review this PR on Baz</a> | <a href="https://main.baz.ninja/agents/baz">Customize your next review</a></sub>