### PR TITLE
feat: add /baz:plan-with-baz planning command skill

### DIFF
--- a/.cursor/rules/baz-codebase-exploration.mdc
+++ b/.cursor/rules/baz-codebase-exploration.mdc
@@ -5,13 +5,14 @@ alwaysApply: true
 
 # Baz Codebase Exploration
 
-This rule applies when planning a feature against repos that are not cloned locally. **Baz MCP tools replace `gh` / `glab` for code search.** Use `gh` / `glab` only to read a specific file once you already know its path.
+This rule applies when planning a change across your org's repos. It applies whether or not the relevant repos are cloned locally — and **especially when a change crosses a contract boundary between repos**: you edit one side, another repo defines the other. **Baz MCP tools replace `gh` / `glab` for code search.** Use `gh` / `glab` only to read a specific file once you already know its path.
 
 ## When this rule fires
 
 - The user asks to plan a feature, scope a change, or design an implementation
-- The relevant code lives in repos the user has not cloned locally
 - The change might touch more than one repository in the org
+- You own one side of a cross-repo contract (API param, request/response schema, event payload) — **even when that side is checked out locally**
+- The relevant code lives in repos the user has not cloned locally
 
 ## Tool routing — strict
 
@@ -91,3 +92,4 @@ Based on what you found, propose:
 - Do **not** ask the user to clone repos for you.
 - Do **not** re-query `repo_search` with rephrased keywords. One call, then pick a repo.
 - Do **not** run `remote_file_search` and `gh` tree-listing for the same directory.
+- Do **not** delegate this exploration to a generic or local-only subagent (e.g. a plain `Explore` agent) — it silently falls back to local Read/Grep and skips Baz. If you spawn a subagent and the work reaches code outside the local checkout (another repo, or the side of a contract you don't own), its prompt **must** tell it to use the Baz MCP tools (`repo_search` / `remote_grep` / `remote_file_search`) per this rule's routing.

--- a/.cursor/rules/baz-codebase-exploration.mdc
+++ b/.cursor/rules/baz-codebase-exploration.mdc
@@ -40,7 +40,7 @@ If the user has not told you which repo(s) to look in, call `repo_search` **exac
 repo_search(keywords: ["<topic>", "<topic synonym>"], domains?: ["API", "BUSINESS_LOGIC", ...])
 ```
 
-Read the returned `{repoId, repoName, domain, summary}` entries and pick the most likely repos using your own judgement (results are not LLM-ranked).
+Read the returned `{repoId, repoName, domain, summary}` entries and pick the most likely repos using your own judgement (results are not LLM-ranked). Use that identifier **verbatim** in later tools — don't guess `repository` from a local folder or service name (the index may name it differently), and note a service is often indexed as a subdirectory of a larger repo, so prefix `path` accordingly.
 
 **If the result is empty or too large**, do **not** re-call `repo_search` with rephrased keywords. Instead:
 - For empty: pick a likely repo by name and skip to Step 2.

--- a/.cursor/rules/baz-codebase-exploration.mdc
+++ b/.cursor/rules/baz-codebase-exploration.mdc
@@ -80,6 +80,8 @@ If you find yourself wanting to *look around* (list a directory, walk a tree), s
 
 ### Step 4: Produce the plan
 
+If the change depends on something in another repo — an API, schema, or contract you don't own — verify it from source with Baz before finalizing, rather than assuming it's already in place.
+
 Based on what you found, propose:
 
 - The files that need to change (with repo + path)

--- a/.cursor/rules/baz-codebase-exploration.mdc
+++ b/.cursor/rules/baz-codebase-exploration.mdc
@@ -3,6 +3,8 @@ description: Baz codebase exploration — use indexed grep, file-glob, and repo-
 alwaysApply: true
 ---
 
+<!-- Mirror of skills/baz-codebase-exploration/SKILL.md (Cursor rules format). Keep the two in sync when editing. -->
+
 # Baz Codebase Exploration
 
 This rule applies when planning a change across your org's repos. It applies whether or not the relevant repos are cloned locally — and **especially when a change crosses a contract boundary between repos**: you edit one side, another repo defines the other. **Baz MCP tools replace `gh` / `glab` for code search.** Use `gh` / `glab` only to read a specific file once you already know its path.

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .idea/
 .vscode/
 *.log
+
+# local plugin/skill testing
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,23 @@ hooks/
   hooks.codex.json              Codex hooks: PostToolUse + Stop, ${CODEX_PLUGIN_DIR}
   hooks.cursor.json             Cursor hooks: postToolUse + stop, ${CURSOR_PLUGIN_ROOT}
 
-skills/baz-codebase-exploration/SKILL.md   Skill injected into context on install
-.cursor/rules/baz-codebase-exploration.mdc Same skill, Cursor rules format
+skills/baz-codebase-exploration/SKILL.md   Reference skill: auto-loaded tool-routing rules
+skills/plan-with-baz/SKILL.md              Task skill: manual /baz:plan-with-baz planning command
+.cursor/rules/baz-codebase-exploration.mdc Reference skill, Cursor rules format (always-apply)
 ```
+
+## Skills
+
+Two skills, by type:
+
+- **`baz-codebase-exploration`** — *reference* content. Auto-loaded; the tool-routing rules + search budget. Also mirrored as a Cursor always-apply rule (`.cursor/rules/*.mdc`).
+- **`plan-with-baz`** — *task* content. Manually invoked as `/baz:plan-with-baz` (`disable-model-invocation: true` so Claude won't auto-trigger it). Enters plan mode per-harness, explores via Baz, and emits a plan in a fixed section schema. It defers the detailed routing rules to `baz-codebase-exploration` rather than forking the table.
+
+Both live under `skills/` and ship to all three platforms with no manifest change — Codex and Cursor manifests already point at `./skills/`, Claude Code auto-discovers. The `plan-with-baz` skill is on-demand, so it has **no** `.cursor/rules/*.mdc` mirror (rules are always-apply).
+
+### Plan output schema (Tier-3 contract)
+
+`plan-with-baz` emits a fixed set of sections, in order: **Context · Affected repos & files · Change sequence · Cross-repo coordination · Open questions · Verification**. Keep these headings stable — a future "share / push to Baz" step (rendering plans in the Baz product) will parse them.
 
 ## Hook counter mechanics
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Both live under `skills/` and ship to all three platforms with no manifest chang
 
 ### Plan output schema (Tier-3 contract)
 
-`plan-with-baz` emits a fixed set of sections, **always all of them, in order**: **Context · Affected repos & files · Change sequence · Diagrams · Cross-repo coordination · Open questions · Verification**. Empty sections render as `_None._` rather than being dropped, so the heading order is stable across runs. Diagrams are inline ```mermaid``` blocks (ERD for data-model changes, flow/sequence for non-trivial flows). Keep these headings stable — a future "share / push to Baz" step (rendering plans in the Baz product) will parse them.
+`plan-with-baz` emits a plan in a fixed, ordered section schema — the canonical definition is the Step 3 template in `skills/plan-with-baz/SKILL.md`. Every heading is always emitted in order (empty sections render as `_None._`), and diagrams are inline ```mermaid``` blocks. Keep that template stable — a future "share / push to Baz" step (rendering plans in the Baz product) will parse these headings. Edit the schema in the skill, not here.
 
 ## Hook counter mechanics
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Both live under `skills/` and ship to all three platforms with no manifest chang
 
 ### Plan output schema (Tier-3 contract)
 
-`plan-with-baz` emits a fixed set of sections, in order: **Context · Affected repos & files · Change sequence · Cross-repo coordination · Open questions · Verification**. Keep these headings stable — a future "share / push to Baz" step (rendering plans in the Baz product) will parse them.
+`plan-with-baz` emits a fixed set of sections, **always all of them, in order**: **Context · Affected repos & files · Change sequence · Diagrams · Cross-repo coordination · Open questions · Verification**. Empty sections render as `_None._` rather than being dropped, so the heading order is stable across runs. Diagrams are inline ```mermaid``` blocks (ERD for data-model changes, flow/sequence for non-trivial flows). Keep these headings stable — a future "share / push to Baz" step (rendering plans in the Baz product) will parse them.
 
 ## Hook counter mechanics
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,23 @@ Cursor doesn't auto-install MCP servers. Two manual steps:
 - **`remote_grep(repository, pattern, path)`** — indexed regex grep inside one repo, scoped to a path. ~2 lines of context per match.
 - **`remote_file_search(repository, pattern)`** — glob file-name search inside one repo. Useful when you have a naming hunch but not the exact path.
 
-The skill teaches the agent when to use which, and to stop searching and start reading once it has a hit.
+The `baz-codebase-exploration` skill teaches the agent when to use which, and to stop searching and start reading once it has a hit. It loads automatically when relevant.
+
+## Planning command
+
+The plugin also ships a manually-invoked planning command, **`/baz:plan-with-baz`**. Run it with a short description of what you want to build:
+
+```text
+/baz:plan-with-baz add rate limiting to the public API
+```
+
+It enters plan mode (where the harness supports it), explores the relevant repos with the Baz tools — including repos you haven't checked out — and writes a structured implementation plan you approve before any code is written.
+
+| Platform | How to invoke | Plan mode |
+|---|---|---|
+| Claude Code | `/baz:plan-with-baz <description>` | enters plan mode automatically (one-click confirm) |
+| Cursor | `/plan-with-baz <description>` | prompts you to switch to Plan mode |
+| Codex | invoke the `plan-with-baz` skill | runs read-only, no writes until you approve |
 
 ## License
 

--- a/skills/baz-codebase-exploration/SKILL.md
+++ b/skills/baz-codebase-exploration/SKILL.md
@@ -89,6 +89,8 @@ If you find yourself wanting to *look around* (list a directory, walk a tree), s
 
 ### Step 4: Produce the plan
 
+If the change depends on something in another repo — an API, schema, or contract you don't own — verify it from source with Baz before finalizing, rather than assuming it's already in place.
+
 Based on what you found, propose:
 
 - The files that need to change (with repo + path)

--- a/skills/baz-codebase-exploration/SKILL.md
+++ b/skills/baz-codebase-exploration/SKILL.md
@@ -49,7 +49,7 @@ If the user has not told you which repo(s) to look in, call `repo_search` **exac
 repo_search(keywords: ["<topic>", "<topic synonym>"], domains?: ["API", "BUSINESS_LOGIC", ...])
 ```
 
-Read the returned `{repoId, repoName, domain, summary}` entries and pick the most likely repos using your own judgement (results are not LLM-ranked).
+Read the returned `{repoId, repoName, domain, summary}` entries and pick the most likely repos using your own judgement (results are not LLM-ranked). Use that identifier **verbatim** in later tools — don't guess `repository` from a local folder or service name (the index may name it differently), and note a service is often indexed as a subdirectory of a larger repo, so prefix `path` accordingly.
 
 **If the result is empty or too large**, do **not** re-call `repo_search` with rephrased keywords. Instead:
 - For empty: pick a likely repo by name and skip to Step 2.

--- a/skills/baz-codebase-exploration/SKILL.md
+++ b/skills/baz-codebase-exploration/SKILL.md
@@ -3,22 +3,25 @@ name: baz-codebase-exploration
 description: >
   Procedure for exploring repositories with Baz's indexed search tools.
   Use when asked to plan a feature, design a change, scope work, or
-  investigate where to make changes — especially when the relevant
-  repositories are not checked out locally. Baz's MCP tools replace
-  `gh` / `glab` for code search across the org; `gh` / `glab` are only
-  for reading specific files once you know the path.
+  investigate where to make changes across the org's repos. Applies even
+  when you own one side of a cross-repo contract (API param, schema, event
+  payload) locally, and especially when the relevant repositories are not
+  checked out locally. Baz's MCP tools replace `gh` / `glab` for code search
+  across the org; `gh` / `glab` are only for reading specific files once you
+  know the path.
 license: MIT
 ---
 
 # Baz Codebase Exploration
 
-This skill helps you plan a feature against repos the user has not cloned locally. **Baz MCP tools replace `gh` / `glab` for code search.** Use `gh` / `glab` only to read a specific file once you already know its path.
+This skill helps you plan a change across your org's repos using indexed search. It applies whether or not the relevant repos are checked out locally — and **especially when a change crosses a contract boundary between repos**: you edit one side, another repo defines the other. **Baz MCP tools replace `gh` / `glab` for code search.** Use `gh` / `glab` only to read a specific file once you already know its path.
 
 ## When to use this skill
 
 - The user asks to plan a feature, scope a change, or design an implementation
-- The relevant code lives in repos the user has not cloned locally
 - The change might touch more than one repository in the org
+- You own one side of a cross-repo contract (API param, request/response schema, event payload) — **even when that side is checked out locally**
+- The relevant code lives in repos the user has not cloned locally
 
 ## Tool routing — strict
 
@@ -98,3 +101,4 @@ Based on what you found, propose:
 - Do **not** ask the user to clone repos for you.
 - Do **not** re-query `repo_search` with rephrased keywords. One call, then pick a repo.
 - Do **not** run `remote_file_search` and `gh` tree-listing for the same directory.
+- Do **not** delegate this exploration to a generic or local-only subagent (e.g. a plain `Explore` agent) — it silently falls back to local Read/Grep and skips Baz. If you spawn a subagent and the work reaches code outside the local checkout (another repo, or the side of a contract you don't own), its prompt **must** tell it to use the Baz MCP tools (`repo_search` / `remote_grep` / `remote_file_search`) per this skill's routing rules.

--- a/skills/plan-with-baz/SKILL.md
+++ b/skills/plan-with-baz/SKILL.md
@@ -14,7 +14,7 @@ license: MIT
 
 You were invoked explicitly to plan a piece of work using Baz's indexed search. The work to plan is in `$ARGUMENTS` (if empty, ask the user what they want to plan).
 
-This is a **read-only** procedure. Do not edit files, run mutating commands, or start implementing until the user approves the plan.
+This is a **read-only** procedure. Do not edit project files, run mutating commands, or start implementing until the user approves the plan. The only write allowed before approval is the plan document itself (see Step 3).
 
 ## Step 1: Enter plan mode
 
@@ -39,10 +39,18 @@ Baz MCP tools replace `gh` / `glab` for *search*; use `gh` / `glab` only to read
 
 ## Step 3: Write the plan
 
-Produce the plan in the fixed schema below — always these sections, in this order. On Claude Code, write it to the plan file plan mode gives you; on other harnesses, write it to `baz-plan.md` in the working directory.
+Produce the plan in the fixed schema below — **always emit every section heading, in this order**, even when a section is empty (write `_None._` rather than dropping the heading). The stable shape is the contract a future "share / push to Baz" step will parse.
+
+Where to put it:
+- **Claude Code**: write it to the plan file plan mode gives you (writing that file is what plan mode is for).
+- **Cursor / Codex** (no plan file): present the plan inline in your response. Do **not** write a file before approval. After the user approves, save it to `baz-plan.md` if they want it persisted.
+
+Add diagrams alongside the prose where they clarify the change — Markdown ```mermaid``` blocks render in all three harnesses:
+- an **ERD** (`erDiagram`) when the change touches a data model / schema;
+- a **flow or sequence diagram** when the change introduces a non-trivial control or data flow.
 
 ```markdown
-# Plan: <title>
+# <title>
 
 ## Context
 Why this change is being made — the problem, what prompted it, the intended outcome.
@@ -54,8 +62,11 @@ Why this change is being made — the problem, what prompted it, the intended ou
 ## Change sequence
 1. Ordered steps to implement.
 
+## Diagrams
+ERD for data-model changes and/or a flow/sequence diagram for non-trivial flows, as ```mermaid``` blocks. `_None._` if neither applies.
+
 ## Cross-repo coordination
-Anything that must land together across repos. Omit if single-repo.
+Anything that must land together across repos. `_None — single-repo change._` if not applicable.
 
 ## Open questions
 Things the user should decide before implementation begins.
@@ -63,8 +74,6 @@ Things the user should decide before implementation begins.
 ## Verification
 How to test the change end-to-end (run the code, MCP tools, tests).
 ```
-
-Keep these section headings stable and exact — they are the contract a future "share / push to Baz" step will parse.
 
 ## Step 4: Get approval
 

--- a/skills/plan-with-baz/SKILL.md
+++ b/skills/plan-with-baz/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: plan-with-baz
+description: >
+  Plan a feature or change end-to-end using Baz indexed search across your
+  org's repos. Enters plan mode, explores the relevant repos with Baz's MCP
+  tools, and produces a structured implementation plan. Invoke with
+  /baz:plan-with-baz when you want to start planning a piece of work.
+disable-model-invocation: true
+argument-hint: [feature or change to plan]
+license: MIT
+---
+
+# Plan with Baz
+
+You were invoked explicitly to plan a piece of work using Baz's indexed search. The work to plan is in `$ARGUMENTS` (if empty, ask the user what they want to plan).
+
+This is a **read-only** procedure. Do not edit files, run mutating commands, or start implementing until the user approves the plan.
+
+## Step 1: Enter plan mode
+
+Get into plan mode before exploring, where the harness supports it:
+
+- **Claude Code**: if you are not already in plan mode, call the `EnterPlanMode` tool now (the user confirms with one click), then continue.
+- **Cursor**: tell the user to switch to **Plan** mode (Cmd/Ctrl+Shift+P toggle), then continue.
+- **Codex** (or any harness without plan mode): there is no mode to enter — just follow this procedure read-only and do not write any files until the plan is approved.
+
+## Step 2: Explore with Baz
+
+Follow the tool-routing rules in the **`baz-codebase-exploration`** skill. The essentials:
+
+| Job | Tool |
+|---|---|
+| Find which repos are involved | `repo_search` (Baz) |
+| Find code by symbol / regex inside a repo | `remote_grep` (Baz) |
+| Find files by name / glob inside a repo | `remote_file_search` (Baz) |
+| Read a specific file you already know the path of | `gh api repos/<owner>/<repo>/contents/<path>` |
+
+Baz MCP tools replace `gh` / `glab` for *search*; use `gh` / `glab` only to read a known path. **Search budget:** call `repo_search` once, don't rephrase keywords, and after 3 searches on the same `(repository, path)` pair read a matched file before searching that pair again. A good run uses fewer than 10 searches total. See `baz-codebase-exploration` for the full rules and forbidden patterns.
+
+## Step 3: Write the plan
+
+Produce the plan in the fixed schema below — always these sections, in this order. On Claude Code, write it to the plan file plan mode gives you; on other harnesses, write it to `baz-plan.md` in the working directory.
+
+```markdown
+# Plan: <title>
+
+## Context
+Why this change is being made — the problem, what prompted it, the intended outcome.
+
+## Affected repos & files
+- `<repo> · <path>` — what changes here and why
+  (works for repos not checked out locally — that's the point of Baz)
+
+## Change sequence
+1. Ordered steps to implement.
+
+## Cross-repo coordination
+Anything that must land together across repos. Omit if single-repo.
+
+## Open questions
+Things the user should decide before implementation begins.
+
+## Verification
+How to test the change end-to-end (run the code, MCP tools, tests).
+```
+
+Keep these section headings stable and exact — they are the contract a future "share / push to Baz" step will parse.
+
+## Step 4: Get approval
+
+Present the plan and ask the user to approve before any implementation begins (on Claude Code, exit plan mode to request approval). Do not start editing until they say go.


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Describe the new <code>/baz:plan-with-baz</code> task skill, the README/CLAUDE guidance, and the implicit plan mode contract so agents can enter plan mode, use Baz MCP search, and emit the ordered Tier-3 plan schema before editing code. Clarify the <code>baz-codebase-exploration</code> routing rules (Cursor mirror included) so agents know when multi-repo or cross-contract exploration requires Baz and how to respect Baz repo identifiers.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/baz-plugin/8?tool=ast&topic=Exploration+rules>Exploration rules</a>
        </td><td>Clarify the <code>baz-codebase-exploration</code> routing rules and Cursor mirror so agents trigger Baz MCP search whenever work spans multiple repos or a contract boundary, use reported repo identifiers verbatim, and require Baz-aware subagents before finalizing cross-repo plans.<details><summary>Modified files (2)</summary><ul><li>.cursor/rules/baz-codebase-exploration.mdc</li>
<li>skills/baz-codebase-exploration/SKILL.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsah@Tsahs-MacBook-Pro...</td><td>docs: reduce drift bet...</td><td>June 30, 2026</td></tr>
<tr><td>tsah@Mac.lan</td><td>fix: resolve repo iden...</td><td>June 29, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://main.baz.ninja/changes/baz-scm/baz-plugin/8?tool=ast&topic=Local+test+ignore>Local test ignore</a>
        </td><td>Add <code>.claude/</code> to <code>.gitignore</code> so the Baz skills/plugin can drop local plugin and skill test artifacts without polluting the repo, keeping developer tooling builds isolated.<details><summary>Modified files (1)</summary><ul><li>.gitignore</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsah@Mac.lan</td><td>fix: stop baz-codebase...</td><td>June 29, 2026</td></tr>
<tr><td>yardenmintz@gmail.com</td><td>Initial: Claude Code +...</td><td>June 21, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://main.baz.ninja/changes/baz-scm/baz-plugin/8?tool=ast&topic=Baz+planning+command>Baz planning command</a>
        </td><td>Introduce the <code>/baz:plan-with-baz</code> command and its skill so agents enter plan mode across Claude/Cursor/Codex, explore using Baz MCP tools, and emit the fixed plan schema documented in the README, CLAUDE manifest, and skill contract before making any edits.<details><summary>Modified files (3)</summary><ul><li>CLAUDE.md</li>
<li>README.md</li>
<li>skills/plan-with-baz/SKILL.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsah@Tsahs-MacBook-Pro...</td><td>docs: reduce drift bet...</td><td>June 30, 2026</td></tr>
<tr><td>tsah@Mac.lan</td><td>fix: address review fe...</td><td>June 29, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://main.baz.ninja/changes/baz-scm/baz-plugin/8?tool=ast">Review this PR on Baz</a> | <a href="https://main.baz.ninja/agents/baz">Customize your next review</a></sub>