### PR TITLE
feat(planner): CR-4545 Add 2 more hooks to extract session and repo and send session complete

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -20,7 +20,7 @@
   "interface": {
     "displayName": "Baz",
     "shortDescription": "Indexed code search across your org.",
-    "longDescription": "Baz adds three indexed search tools (cross_repo_search, remote_grep, remote_file_search) for planning features against repos you haven't checked out. Includes the codebase-exploration skill that routes search to Baz and reads to gh / glab.",
+    "longDescription": "Baz adds three indexed search tools (repo_search, remote_grep, remote_file_search) for planning features against repos you haven't checked out. Includes the codebase-exploration skill that routes search to Baz and reads to gh / glab.",
     "category": "Productivity",
     "capabilities": [
       "Instructions",

--- a/.cursor/rules/baz-codebase-exploration.mdc
+++ b/.cursor/rules/baz-codebase-exploration.mdc
@@ -97,3 +97,11 @@ Based on what you found, propose:
 - Do **not** re-query `repo_search` with rephrased keywords. One call, then pick a repo.
 - Do **not** run `remote_file_search` and `gh` tree-listing for the same directory.
 - Do **not** delegate this exploration to a generic or local-only subagent (e.g. a plain `Explore` agent) — it silently falls back to local Read/Grep and skips Baz. If you spawn a subagent and the work reaches code outside the local checkout (another repo, or the side of a contract you don't own), its prompt **must** tell it to use the Baz MCP tools (`repo_search` / `remote_grep` / `remote_file_search`) per this rule's routing.
+
+## Session tracking — required
+
+The baz plugin's `sessionStart` hook injects your `sessionId` and the cwd repo (`sessionRepository`) into your context. **You MUST pass both as arguments on every call to `repo_search`, `remote_grep`, and `remote_file_search`.** Without them, baz cannot correlate your tool calls to a session and the calls are dropped from baz's timeline. This is non-negotiable — treat the values as required, not optional, regardless of what the tool schema marks them as.
+
+### Closing the session — required at end of planning
+
+When you've finished planning and are ready to present the plan to the user, **write the final plan to `/tmp/.baz-plan-<sessionId>.md`** (substitute your real sessionId). A `postToolUse` hook watches for that exact path and will immediately inject a follow-up instruction telling you to call `mcp__baz__complete_session`. **Your next tool call after writing the file MUST be `mcp__baz__complete_session`** (fully qualified — not `complete_session` alone, which is not a callable tool name); pass the `sessionId` and the `completedAt` timestamp from the hook's instruction. Don't respond to the user or run any other tool in between. Skipping this leaves the session open in baz's timeline forever. Call it exactly once per planning session.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # baz-plugin
 
-Plugin for Claude Code, Codex CLI, and Cursor that adds Baz indexed search tools and a session-level tool-usage summary hook.
+Plugin for Claude Code, Codex CLI, and Cursor that adds Baz indexed search tools. All three platforms wire a session-start hook that surfaces session id + cwd repo so baz can correlate tool calls, and a PostToolUse hook that watches for the agent writing its final plan to `/tmp/.baz-plan-<sessionId>.md` — that file-write is the cross-platform "I'm done planning" signal that nudges the agent to call `mcp__baz__complete_session` and emit the `mcp_session_completed` timeline event.
 
 ## Repo layout
 
@@ -10,12 +10,14 @@ Plugin for Claude Code, Codex CLI, and Cursor that adds Baz indexed search tools
 .cursor-plugin/plugin.json      Cursor plugin manifest
 
 hooks/
+  session-start.js              Shared: emits additionalContext telling the assistant the session id + cwd repo (allowlist-validated), so it passes them through to baz MCP tools for session correlation. Handles `cwd` (CC/Codex) and `workspace_roots[0]` (Cursor).
+  plan-complete.js              Shared completion trigger: prompts the agent to call mcp__baz__complete_session. Branches on tool_name — ExitPlanMode (CC plan mode) always fires; file-write tools (Write/Edit/apply_patch/edit_file/write_file) fire only when the path matches /tmp/.baz-plan-<sessionId>.md. CC wires both branches; Cursor/Codex have no ExitPlanMode and rely on the file-write branch.
   post-tool-use.js              Shared: increments per-tool counter in /tmp on each Baz MCP call
   session-end.js                Shared: prints call summary to console at session end, cleans up /tmp
 
-  hooks.json                    CC hooks: PostToolUse + SessionEnd, ${CLAUDE_PLUGIN_ROOT}
-  hooks.codex.json              Codex hooks: PostToolUse + Stop, ${CODEX_PLUGIN_DIR}
-  hooks.cursor.json             Cursor hooks: postToolUse + stop, ${CURSOR_PLUGIN_ROOT}
+  hooks.json                    CC hooks: SessionStart + PostToolUse (mcp__baz__ + Write|Edit) + SessionEnd, ${CLAUDE_PLUGIN_ROOT}
+  hooks.codex.json              Codex hooks: SessionStart + PostToolUse (mcp__baz__ + apply_patch|Write|Edit) + Stop, ${CODEX_PLUGIN_DIR}
+  hooks.cursor.json             Cursor hooks: sessionStart + postToolUse (mcp__baz__ + edit_file|write_file|Write|Edit) + stop, ${CURSOR_PLUGIN_ROOT}
 
 skills/baz-codebase-exploration/SKILL.md   Reference skill: auto-loaded tool-routing rules
 skills/plan-with-baz/SKILL.md              Task skill: manual /baz:plan-with-baz planning command
@@ -39,17 +41,33 @@ Both live under `skills/` and ship to all three platforms with no manifest chang
 
 `post-tool-use.js` writes to `/tmp/.baz-counts-<session_id>.json`. `session-end.js` reads, prints, and deletes it. Scripts are shared across all three platforms — only the hook manifests differ (event names, path variables).
 
-| Platform | Tool event | Session-end event | Path variable |
-|---|---|---|---|
-| Claude Code | `PostToolUse` | `SessionEnd` | `${CLAUDE_PLUGIN_ROOT}` |
-| Codex | `PostToolUse` | `Stop` | `${CODEX_PLUGIN_DIR}` |
-| Cursor | `postToolUse` | `stop` | `${CURSOR_PLUGIN_ROOT}` |
+| Platform | Session-start event | Tool event | Session-end event | Path variable |
+|---|---|---|---|---|
+| Claude Code | `SessionStart` | `PostToolUse` | `SessionEnd` | `${CLAUDE_PLUGIN_ROOT}` |
+| Codex | `SessionStart` | `PostToolUse` | `Stop` | `${CODEX_PLUGIN_DIR}` |
+| Cursor | `sessionStart` | `postToolUse` | `stop` | `${CURSOR_PLUGIN_ROOT}` |
+
+## Completion-trigger design
+
+`mcp_session_completed` is emitted by the agent itself via `mcp__baz__complete_session`. The agent needs a "planning is over" signal, but the right signal differs per platform:
+
+- **Claude Code**: two PostToolUse matchers both point at `plan-complete.js` — `ExitPlanMode` (CC's native end-of-planning tool, used when the agent is in plan mode which blocks file writes) and `Write|Edit` (the file-write branch, fires when the agent plans without entering plan mode and writes the plan file inline).
+- **Cursor / Codex**: no `ExitPlanMode` tool. SKILL.md / `.cursor/rules/...mdc` / `AGENTS.md` instruct the agent to write its final plan to `/tmp/.baz-plan-<sessionId>.md` at end of planning; `plan-complete.js` matches that write across the platform's file-write tools (`apply_patch|Write|Edit` on Codex, `edit_file|write_file|Write|Edit` on Cursor) and injects the nudge.
+
+Both paths converge on `mcp__baz__complete_session`. BFF flips the row to `status='success'` with `completed_at` set.
+
 
 ## Adding a new hook
 
 1. Edit the shared JS files in `hooks/` if logic changes.
-2. Update all three `hooks.*.json` files if the event or structure changes.
-3. Hook matcher `mcp__baz__` catches all three Baz MCP tools (`cross_repo_search`, `remote_grep`, `remote_file_search`).
+2. **Shared events** (e.g. `SessionStart`, `PostToolUse` counter, session-end summary):
+   update all three `hooks.*.json` files. Note that Cursor uses camelCase event
+   names + a flatter manifest shape (no nested `hooks` array, command directly on the entry).
+3. The `PostToolUse` block in `hooks.json` has three matchers today:
+   - `mcp__baz__` → `post-tool-use.js` (counts baz MCP tool calls)
+   - `Write|Edit` → `plan-complete.js` (file-write branch: fires when the agent writes `/tmp/.baz-plan-<sessionId>.md` outside plan mode)
+   - `ExitPlanMode` → `plan-complete.js` (plan-mode branch: fires when the agent exits CC's plan mode)
+   Add new matchers as additional entries in the same `PostToolUse` array.
 
 ## MCP server
 

--- a/hooks/hooks.codex.json
+++ b/hooks/hooks.codex.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CODEX_PLUGIN_DIR}/hooks/session-start.js\""
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "mcp__baz__",
@@ -7,6 +17,15 @@
           {
             "type": "command",
             "command": "node \"${CODEX_PLUGIN_DIR}/hooks/post-tool-use.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "apply_patch|Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CODEX_PLUGIN_DIR}/hooks/plan-complete.js\""
           }
         ]
       }

--- a/hooks/hooks.cursor.json
+++ b/hooks/hooks.cursor.json
@@ -1,10 +1,19 @@
 {
   "version": 1,
   "hooks": {
+    "sessionStart": [
+      {
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/hooks/session-start.js\""
+      }
+    ],
     "postToolUse": [
       {
         "matcher": "mcp__baz__",
         "command": "node \"${CURSOR_PLUGIN_ROOT}/hooks/post-tool-use.js\""
+      },
+      {
+        "matcher": "edit_file|write_file|Write|Edit",
+        "command": "node \"${CURSOR_PLUGIN_ROOT}/hooks/plan-complete.js\""
       }
     ],
     "stop": [

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.js\""
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "mcp__baz__",
@@ -7,6 +17,24 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/plan-complete.js\""
+          }
+        ]
+      },
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/plan-complete.js\""
           }
         ]
       }

--- a/hooks/plan-complete.js
+++ b/hooks/plan-complete.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+
+// PostToolUse hook that emits the "call mcp__baz__complete_session next" nudge
+// once planning is done. Two trigger paths converge here:
+//
+//   1. CC's ExitPlanMode — agent used plan mode (which blocks file writes, so
+//      path 2 can't fire). Always nudge on this tool.
+//   2. File-write tools (Write/Edit/apply_patch/edit_file/write_file) — agent
+//      planned inline and wrote its final plan to /tmp/.baz-plan-<sessionId>.md
+//      per SKILL.md / .cursor/rules / AGENTS.md. Filter by filename so unrelated
+//      writes don't fire.
+//
+// File-path match is done against the stringified tool input — each platform
+// names the path field differently (file_path / path / apply_patch arg blob).
+// We match by filename only because macOS resolves /tmp to /private/tmp before
+// the path reaches the hook.
+
+const input = fs.readFileSync('/dev/stdin', 'utf8');
+let d;
+try { d = JSON.parse(input); } catch { process.exit(0); }
+
+const sessionId = d.session_id || '';
+if (!sessionId) process.exit(0);
+
+if ((d.tool_name || '') !== 'ExitPlanMode') {
+  const planFilename = `.baz-plan-${sessionId}.md`;
+  const haystack = JSON.stringify(d.tool_input || d);
+  if (!haystack.includes(planFilename)) process.exit(0);
+}
+
+const completedAt = new Date().toISOString();
+const instruction =
+  `REQUIRED — DO THIS NOW: You just finished planning. ` +
+  `Your next tool invocation MUST be \`mcp__baz__complete_session\` with ` +
+  `\`sessionId: "${sessionId}"\` and \`completedAt: "${completedAt}"\`. ` +
+  `This is the signal baz uses to close the planning session in its timeline. ` +
+  `Call it exactly once, before responding to the user or running any other tool.`;
+
+process.stdout.write(JSON.stringify({
+  hookSpecificOutput: {
+    hookEventName: 'PostToolUse',
+    additionalContext: instruction,
+  },
+}));

--- a/hooks/session-start.js
+++ b/hooks/session-start.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+// The HTTP MCP transport in Claude Code does not expand header value
+// substitutions (e.g. `${CLAUDE_SESSION_ID}`), so the `x-session-id` header
+// in the plugin manifest never reaches the MCP server. This hook works around
+// that by surfacing both `sessionId` and the cwd's `owner/repo` to the
+// assistant via additionalContext, and instructing it to pass them as tool
+// arguments on every baz planning tool call.
+
+const input = fs.readFileSync('/dev/stdin', 'utf8');
+const d = JSON.parse(input);
+
+const sessionId = d.session_id || '';
+// Claude Code + Codex send `cwd` on the hook payload.
+// Cursor sends `workspace_roots: [<path>, ...]` instead — use the first entry.
+const cwd =
+  d.cwd ||
+  (Array.isArray(d.workspace_roots) && d.workspace_roots.length > 0
+    ? d.workspace_roots[0]
+    : '');
+
+if (!sessionId) process.exit(0);
+
+const SAFE_REPO = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+let sessionRepo = '';
+if (cwd) {
+  try {
+    const remote = execSync('git config --get remote.origin.url', {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    }).trim();
+    if (remote) {
+      const m = remote.match(/[:/]([^/:]+\/[^/:]+?)(?:\.git)?\/?$/);
+      const candidate = m ? m[1] : '';
+      if (SAFE_REPO.test(candidate)) sessionRepo = candidate;
+    }
+  } catch {
+    // No git remote / not a git repo / git missing — fall through.
+  }
+}
+
+let instruction = `Your agent session id is \`${sessionId}\`.`;
+let args = `\`sessionId: "${sessionId}"\``;
+if (sessionRepo) {
+  instruction += ` You are running in repo \`${sessionRepo}\`.`;
+  args += `, \`sessionRepository: "${sessionRepo}"\``;
+}
+instruction += ` When calling baz planning MCP tools (\`mcp__baz__repo_search\`, \`mcp__baz__remote_file_search\`, \`mcp__baz__remote_grep\`), always include ${args} as arguments. This is required for baz to correlate tool calls back to this session and the repo you are working in.`;
+
+process.stdout.write(JSON.stringify({
+  hookSpecificOutput: {
+    hookEventName: 'SessionStart',
+    additionalContext: instruction,
+  },
+}));

--- a/skills/baz-codebase-exploration/SKILL.md
+++ b/skills/baz-codebase-exploration/SKILL.md
@@ -104,3 +104,13 @@ Based on what you found, propose:
 - Do **not** re-query `repo_search` with rephrased keywords. One call, then pick a repo.
 - Do **not** run `remote_file_search` and `gh` tree-listing for the same directory.
 - Do **not** delegate this exploration to a generic or local-only subagent (e.g. a plain `Explore` agent) — it silently falls back to local Read/Grep and skips Baz. If you spawn a subagent and the work reaches code outside the local checkout (another repo, or the side of a contract you don't own), its prompt **must** tell it to use the Baz MCP tools (`repo_search` / `remote_grep` / `remote_file_search`) per this skill's routing rules.
+
+## Session tracking — required
+
+The baz plugin's SessionStart hook injects your `sessionId` and the cwd repo (`sessionRepository`) into your context. **You MUST pass both as arguments on every call to `repo_search`, `remote_grep`, and `remote_file_search`.** Without them, baz cannot correlate your tool calls to a session and the calls are dropped from baz's timeline. This is non-negotiable — treat the values as required, not optional, regardless of what the tool schema marks them as.
+
+### Closing the session — required at end of planning
+
+When you've finished planning and are ready to present the plan to the user, **write the final plan to `/tmp/.baz-plan-<sessionId>.md`** (substitute your real sessionId). A PostToolUse hook watches for that exact path and will immediately inject a follow-up instruction telling you to call `mcp__baz__complete_session`. **Your next tool call after writing the file MUST be `mcp__baz__complete_session`** (fully qualified — not `complete_session` alone, which is not a callable tool name); pass the `sessionId` and the `completedAt` timestamp from the hook's instruction. Don't respond to the user or run any other tool in between. Skipping this leaves the session open in baz's timeline forever. Call it exactly once per planning session.
+
+This applies to Claude Code, Codex, and Cursor — the plan-file convention replaces the older Claude-Code-only ExitPlanMode trigger.


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Clarify the Baz plugin metadata, skill docs, and hook wiring so every platform surfaces the planner session id/repo context before invoking Baz MCP tools. Ensure the session-completion path directs agents to write <code>/tmp/.baz-plan-<sessionId>.md</code> (or exit plan mode) and immediately call <code>mcp__baz__complete_session</code> via the new <code>plan-complete.js</code> hook.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://main.baz.ninja/changes/baz-scm/baz-plugin/9?tool=ast&topic=Plan+completion>Plan completion</a>
        </td><td>Signal planning completion by matching either Claude Code’s <code>ExitPlanMode</code> or the cross-platform <code>/tmp/.baz-plan-<sessionId>.md</code> file-write, running <code>plan-complete.js</code> to nudge the agent to call <code>mcp__baz__complete_session</code>, and documenting the approach in the shared docs and hooks so the timeline closes with a success event.<details><summary>Modified files (6)</summary><ul><li>CLAUDE.md</li>
<li>hooks/hooks.codex.json</li>
<li>hooks/hooks.cursor.json</li>
<li>hooks/hooks.json</li>
<li>hooks/plan-complete.js</li>
<li>skills/baz-codebase-exploration/SKILL.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsah@baz.co</td><td>feat: add /baz:plan-wi...</td><td>June 30, 2026</td></tr>
<tr><td>yardenmintz@gmail.com</td><td>Add 2 more hooks to ex...</td><td>June 29, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://main.baz.ninja/changes/baz-scm/baz-plugin/9?tool=ast&topic=Session+tracking>Session tracking</a>
        </td><td>Enforce session metadata propagation by wiring the shared <code>SessionStart</code> hook into Claude Code, Codex, and Cursor manifests, updating the Baz interface copy, and refreshing the guidance (<code>CLAUDE.md</code>, <code>.cursor/rules/baz-codebase-exploration.mdc</code>, <code>skills/baz-codebase-exploration/SKILL.md</code>) so every <code>repo_search</code>/<code>remote_grep</code>/<code>remote_file_search</code> call carries the <code>sessionId</code> and <code>sessionRepository</code> arguments required for Baz to correlate tool use.<details><summary>Modified files (8)</summary><ul><li>.codex-plugin/plugin.json</li>
<li>.cursor/rules/baz-codebase-exploration.mdc</li>
<li>CLAUDE.md</li>
<li>hooks/hooks.codex.json</li>
<li>hooks/hooks.cursor.json</li>
<li>hooks/hooks.json</li>
<li>hooks/session-start.js</li>
<li>skills/baz-codebase-exploration/SKILL.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>tsah@baz.co</td><td>feat: add /baz:plan-wi...</td><td>June 30, 2026</td></tr>
<tr><td>yardenmintz@gmail.com</td><td>Add 2 more hooks to ex...</td><td>June 29, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://main.baz.ninja/changes/baz-scm/baz-plugin/9?tool=ast">Review this PR on Baz</a> | <a href="https://main.baz.ninja/agents/baz">Customize your next review</a></sub>