### PR TITLE
feat(statusline): show baz tool usage in the Claude Code status line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,12 @@ hooks/
   post-tool-use.js              Shared: increments per-tool counter in /tmp on each Baz MCP call
   session-end.js                Shared: prints call summary to console at session end, cleans up /tmp
 
-  hooks.json                    CC hooks: SessionStart + PostToolUse (mcp__baz__ + Write|Edit) + SessionEnd, ${CLAUDE_PLUGIN_ROOT}
-  hooks.codex.json              Codex hooks: SessionStart + PostToolUse (mcp__baz__ + apply_patch|Write|Edit) + Stop, ${CODEX_PLUGIN_DIR}
-  hooks.cursor.json             Cursor hooks: sessionStart + postToolUse (mcp__baz__ + edit_file|write_file|Write|Edit) + stop (stop-token-tally.js only). No session-end wiring — Cursor's validator does not accept `sessionEnd`; see Hook counter mechanics for the counter-file trade-off. ${CURSOR_PLUGIN_ROOT}
+  hooks.json                    CC hooks: SessionStart + PostToolUse (baz MCP + Write|Edit) + SessionEnd, ${CLAUDE_PLUGIN_ROOT}
+  hooks.codex.json              Codex hooks: SessionStart + PostToolUse (baz MCP + apply_patch|Write|Edit) + Stop, ${CODEX_PLUGIN_DIR}
+  hooks.cursor.json             Cursor hooks: sessionStart + postToolUse (baz MCP + edit_file|write_file|Write|Edit) + stop (stop-token-tally.js only). No session-end wiring — Cursor's validator does not accept `sessionEnd`; see Hook counter mechanics for the counter-file trade-off. ${CURSOR_PLUGIN_ROOT}
+
+bin/
+  baz-statusline                CC only: status-line script reading the same /tmp counter, prints "baz 7 · grep 4 · repo 2 · files 1". Users wire it via statusLine in their own settings.json — plugin settings.json only supports `agent` and `subagentStatusLine`.
 
 skills/baz-codebase-exploration/SKILL.md   Reference skill: auto-loaded tool-routing rules
 skills/plan-with-baz/SKILL.md              Task skill: manual /baz:plan-with-baz planning command
@@ -53,6 +56,8 @@ All three live under `skills/` and ship to all three platforms with no manifest 
 | Codex | `SessionStart` | `PostToolUse` | `Stop` | `${CODEX_PLUGIN_DIR}` |
 | Cursor | `sessionStart` | `postToolUse` | *(none — see below)* | `${CURSOR_PLUGIN_ROOT}` |
 
+**Tool-name matching — two spellings.** The counter matcher is `mcp__(plugin_)?baz(_baz)?__`, not `mcp__baz__`. Claude Code namespaces a plugin-provided MCP server, so tools arrive as `mcp__plugin_baz_baz__<tool>`; a bare `mcp__baz__` matcher never fires there and the counter file is never created (which also empties `repoNames` on `update_plan`, since `.baz-repos` comes from the same hook). `post-tool-use.js` strips whichever prefix it gets with `^mcp__.*?__` before recording the short tool name. Any change to the plugin or server name has to be reflected in all three manifests.
+
 **Cursor limitation — no counter/summary.** Cursor's hook validator does not recognize `sessionEnd`, and using its per-turn `stop` for `session-end.js` would wipe the counter mid-session. Rather than leak `/tmp/.baz-counts-<sessionId>.json` forever with no reaper, `post-tool-use.js` short-circuits on Cursor payloads (detected via `conversation_id` without `session_id`). Cursor users get no tool-usage summary at session end — accepted as consistent with the "Cursor is best-effort" posture (see the Completion-trigger design section: no automated postToolUse nudge on Cursor either).
 
 **Codex limitation.** Codex has no session-end event — its only lifecycle event past `PostToolUse` is `Stop`, which fires per-turn. That means `session-end.js` on Codex prints/clears the counter after every turn, and the summary reflects only the last turn's calls. Fixing this requires either an upstream Codex hook addition or a different consumer-owned cleanup pattern.
@@ -74,7 +79,7 @@ Both paths converge on `mcp__baz__update_plan`. BFF upserts the plan and flips t
    update all three `hooks.*.json` files. Note that Cursor uses camelCase event
    names + a flatter manifest shape (no nested `hooks` array, command directly on the entry).
 3. The `PostToolUse` block in `hooks.json` has three matchers today:
-   - `mcp__baz__` → `post-tool-use.js` (counts baz MCP tool calls)
+   - `mcp__(plugin_)?baz(_baz)?__` → `post-tool-use.js` (counts baz MCP tool calls; see Hook counter mechanics for why both spellings)
    - `Write|Edit` → `plan-complete.js` (file-write branch: fires when the agent writes `/tmp/.baz-plan-<sessionId>.md` outside plan mode)
    - `ExitPlanMode` → `plan-complete.js` (plan-mode branch: fires when the agent exits CC's plan mode)
    Add new matchers as additional entries in the same `PostToolUse` array.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,29 @@ With `--fix` (or when you ask afterwards), it turns the findings into a task lis
 | Cursor | `/review [scope]` |
 | Codex | invoke the `review` skill |
 
+## Status line
+
+Claude Code only. `bin/baz-statusline` renders this session's Baz tool usage as a status-line row:
+
+```text
+baz 7 · grep 4 · repo 2 · files 1
+```
+
+Plugins can't ship a `statusLine` of their own, so add it to your `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "baz-statusline"
+  }
+}
+```
+
+The plugin's `bin/` is on Claude Code's `PATH` while the plugin is enabled. If the row stays blank after a Baz search, point `command` at the script's absolute path under `~/.claude/plugins/cache/baz/baz/<version>/bin/` instead — note that path carries the plugin version and changes on update.
+
+The row is empty until the session's first Baz call, and empties again at session end when the counter file is reaped. It reads the same counter that prints the end-of-session usage summary.
+
 ## License
 
 MIT

--- a/bin/baz-statusline
+++ b/bin/baz-statusline
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// Status line segment: tallies this session's baz MCP calls from the counter
+// file `post-tool-use.js` appends to, and prints one line:
+//
+//   baz 7 · grep 4 · repo 2 · files 1
+//
+// Prints nothing until the session has made its first baz call, and exits
+// quietly on any read/parse failure — a status line must never surface an
+// error into the UI. `session-end.js` deletes the counter file, after which
+// this goes back to printing nothing.
+
+const LABELS = {
+  repo_search: 'repo',
+  remote_grep: 'grep',
+  remote_file_search: 'files',
+  update_plan: 'plan',
+  get_review_discussions: 'discussions',
+  organizational_review_guidelines: 'guidelines',
+  load_resources: 'resources',
+};
+
+let d;
+try {
+  d = JSON.parse(fs.readFileSync('/dev/stdin', 'utf8'));
+} catch {
+  process.exit(0);
+}
+
+// Cursor payloads use `conversation_id`; Claude Code and Codex use `session_id`.
+const sessionId = d.session_id || d.conversation_id || '';
+if (!sessionId) process.exit(0);
+
+let raw;
+try {
+  raw = fs.readFileSync(path.join('/tmp', `.baz-counts-${sessionId}.json`), 'utf8');
+} catch {
+  // No baz call yet this session, or the file was already reaped.
+  process.exit(0);
+}
+
+const lines = raw.split('\n').filter(Boolean);
+if (lines.length === 0) process.exit(0);
+
+const counts = {};
+for (const tool of lines) counts[tool] = (counts[tool] || 0) + 1;
+
+const segments = Object.entries(counts)
+  .sort(([, a], [, b]) => b - a)
+  .map(([tool, count]) => `${LABELS[tool] || tool} ${count}`);
+
+process.stdout.write(`baz ${lines.length} · ${segments.join(' · ')}\n`);

--- a/hooks/hooks.codex.json
+++ b/hooks/hooks.codex.json
@@ -12,7 +12,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__baz__",
+        "matcher": "mcp__(plugin_)?baz(_baz)?__",
         "hooks": [
           {
             "type": "command",

--- a/hooks/hooks.cursor.json
+++ b/hooks/hooks.cursor.json
@@ -8,7 +8,7 @@
     ],
     "postToolUse": [
       {
-        "matcher": "mcp__baz__",
+        "matcher": "mcp__(plugin_)?baz(_baz)?__",
         "command": "node \"${CURSOR_PLUGIN_ROOT}/hooks/post-tool-use.js\""
       },
       {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -12,7 +12,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__baz__",
+        "matcher": "mcp__(plugin_)?baz(_baz)?__",
         "hooks": [
           {
             "type": "command",

--- a/hooks/post-tool-use.js
+++ b/hooks/post-tool-use.js
@@ -13,7 +13,10 @@ if (!sessionId) process.exit(0);
 const isCursor = !d.session_id && d.conversation_id;
 
 if (!isCursor) {
-  const toolName = (d.tool_name || '').split('__baz__')[1] || d.tool_name;
+  // Strip the MCP prefix, which differs per host: `mcp__baz__<tool>` when the
+  // server is wired directly, `mcp__plugin_baz_baz__<tool>` when Claude Code
+  // namespaces it as a plugin-provided server.
+  const toolName = (d.tool_name || '').replace(/^mcp__.*?__/, '') || d.tool_name;
   const logPath = `/tmp/.baz-counts-${sessionId}.json`;
   // Append-only: each call writes one line; avoids concurrent read/modify/write race.
   fs.appendFileSync(logPath, toolName + '\n');


### PR DESCRIPTION
## What

Adds `bin/baz-statusline` — a status-line row showing this session's Baz tool usage:

```text
baz 7 · grep 4 · repo 2 · files 1
```

The counter already existed; it was only ever shown once, as a console dump at `SessionEnd`, after the work was over. During a planning run — when `baz-codebase-exploration` is enforcing its hard 10-search budget — that number is exactly what you want live.

Plugins can't ship a `statusLine` of their own (plugin `settings.json` supports only `agent` and `subagentStatusLine`), so the README documents the snippet users add to their own `~/.claude/settings.json`. The plugin's `bin/` is already on Claude Code's `PATH`, so the command is just `baz-statusline`.

## The counter was dead on Claude Code

Scoping this turned up a live bug. The `PostToolUse` matcher was `mcp__baz__`, but Claude Code namespaces a plugin-provided MCP server, so tools arrive as `mcp__plugin_baz_baz__<tool>` — which does not contain `mcp__baz__`. The hook never fired, and `/tmp/.baz-counts-<sessionId>.json` was never created.

Same hook writes `/tmp/.baz-repos-<sessionId>.json`, so `repoNames` on `update_plan` was empty too — plans have been filed under the session's own repo only, never the repos they were actually about.

Two fixes, both needed for the status line to show anything:

- matcher → `mcp__(plugin_)?baz(_baz)?__` in all three manifests (verified it matches both spellings and rejects `mcp__claude_ai_Baz__*` and other plugins' tools)
- `post-tool-use.js` strips the prefix with `^mcp__.*?__` instead of splitting on a literal `__baz__` the namespaced name doesn't contain — otherwise the counter records `mcp__plugin_baz_baz__remote_grep` as the label

Kept in one PR because the status line is not demonstrable without the fix. Happy to split if you'd rather land the fix on its own.

## Verification

- `bin/baz-statusline` against a populated counter → `baz 7 · grep 4 · repo 2 · files 1`; against a missing file, an empty file, garbage stdin, and a payload with no `session_id` → prints nothing, exits 0
- full pipeline simulated with real namespaced payloads: `post-tool-use.js` → counter + repos files → status line → `session-end.js` summary → status line blank after the reap
- `python3 -m json.tool` over every `*.json` and `plugin validate . --strict` both pass locally

Not yet verified live end-to-end — that needs the plugin reinstalled and Claude Code restarted, since hook manifests load at startup.

## Out of scope, but noticed

The skills and `.cursor/rules` tell the agent to call `mcp__baz__update_plan`, which is not a callable tool name on Claude Code either — it's `mcp__plugin_baz_baz__update_plan` there. Same root cause, different blast radius; left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)