### PR TITLE
fix(hooks): point Codex hook commands at PLUGIN_ROOT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ hooks/
   plan-attach.js                Claude Code only: PreToolUse on mcp__baz__update_plan and mcp__baz__link_plan_to_pr. Fills update_plan with the plan parked by plan-complete.js, so the plan is generated once instead of being re-typed into the call, and fills link_plan_to_pr's planId with the session id. Adds only what is missing, so a call that already carries content (Codex/Cursor) or its own planId passes through.
 
   hooks.json                    CC hooks: SessionStart + PreToolUse (mcp__baz__update_plan|mcp__baz__link_plan_to_pr) + PostToolUse (mcp__baz__ + Write|Edit) + SessionEnd, ${CLAUDE_PLUGIN_ROOT}
-  hooks.codex.json              Codex hooks: SessionStart + PostToolUse (mcp__baz__ + apply_patch|Write|Edit) + Stop, ${CODEX_PLUGIN_DIR}
+  hooks.codex.json              Codex hooks: SessionStart + PostToolUse (mcp__baz__ + apply_patch|Write|Edit) + Stop, ${PLUGIN_ROOT}
   hooks.cursor.json             Cursor hooks: sessionStart + postToolUse (mcp__baz__ + edit_file|write_file|Write|Edit) + stop (stop-token-tally.js only). No session-end wiring — Cursor's validator does not accept `sessionEnd`; see Hook counter mechanics for the counter-file trade-off. ${CURSOR_PLUGIN_ROOT}
 
 skills/baz-codebase-exploration/SKILL.md   Reference skill: auto-loaded tool-routing rules
@@ -101,7 +101,7 @@ The counter file is **claimed by rename before it is read**. Codex fires `Stop` 
 | Platform | Session-start event | Tool event | Session-end event | Path variable |
 |---|---|---|---|---|
 | Claude Code | `SessionStart` | `PreToolUse` + `PostToolUse` | `SessionEnd` | `${CLAUDE_PLUGIN_ROOT}` |
-| Codex | `SessionStart` | `PostToolUse` | `Stop` | `${CODEX_PLUGIN_DIR}` |
+| Codex | `SessionStart` | `PostToolUse` | `Stop` | `${PLUGIN_ROOT}` |
 | Cursor | `sessionStart` | `postToolUse` | *(none — see below)* | `${CURSOR_PLUGIN_ROOT}` |
 
 **Cursor limitation — no counter/summary.** Cursor's hook validator does not recognize `sessionEnd`, and using its per-turn `stop` for `session-end.js` would wipe the counter mid-session. Rather than leak `.baz-counts-<sessionId>.json` forever with no reaper, `post-tool-use.js` short-circuits on Cursor payloads (detected via `conversation_id` without `session_id`). Cursor users get no tool-usage summary at session end — accepted as consistent with the "Cursor is best-effort" posture (see the Completion-trigger design section: no automated postToolUse nudge on Cursor either).

--- a/hooks/hooks.codex.json
+++ b/hooks/hooks.codex.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CODEX_PLUGIN_DIR}/hooks/session-start.js\" codex"
+            "command": "node \"${PLUGIN_ROOT}/hooks/session-start.js\" codex"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CODEX_PLUGIN_DIR}/hooks/post-tool-use.js\""
+            "command": "node \"${PLUGIN_ROOT}/hooks/post-tool-use.js\""
           }
         ]
       },
@@ -25,7 +25,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CODEX_PLUGIN_DIR}/hooks/plan-complete.js\" codex"
+            "command": "node \"${PLUGIN_ROOT}/hooks/plan-complete.js\" codex"
           }
         ]
       }
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CODEX_PLUGIN_DIR}/hooks/session-end.js\" codex"
+            "command": "node \"${PLUGIN_ROOT}/hooks/session-end.js\" codex"
           }
         ]
       }

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -647,6 +647,25 @@ test('a hostile session id cannot touch files outside the scratch dir', ({ env }
   }
 });
 
+console.log('\nmanifests: plugin hook commands use the host path variable');
+
+test('Codex hook commands use PLUGIN_ROOT, not CODEX_PLUGIN_DIR', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(HOOKS, 'hooks.codex.json'), 'utf8'));
+  const commands = [];
+  for (const entries of Object.values(manifest.hooks)) {
+    for (const group of entries) {
+      for (const hook of group.hooks || []) {
+        if (typeof hook.command === 'string') commands.push(hook.command);
+      }
+    }
+  }
+  assert.ok(commands.length > 0, 'no Codex hook commands');
+  for (const command of commands) {
+    assert.match(command, /\$\{PLUGIN_ROOT\}/, `missing PLUGIN_ROOT: ${command}`);
+    assert.doesNotMatch(command, /CODEX_PLUGIN_DIR/, `invented CODEX_PLUGIN_DIR: ${command}`);
+  }
+});
+
 // --- report -----------------------------------------------------------------
 
 console.log(`\n${passed} passed, ${failures.length} failed, ${skipped} skipped`);


### PR DESCRIPTION
## Summary
- Codex plugin hooks used `${CODEX_PLUGIN_DIR}`, which Codex never sets, so SessionStart/Stop exited 1 before injecting a plan-file path.
- Point those commands at `${PLUGIN_ROOT}` (the variable Codex actually substitutes) and lock it with a manifest test.

## Test plan
- [ ] `node tests/hooks.test.js`
- [ ] New Codex session: SessionStart completes and injects `.baz-plan-<sessionId>.md` (no `hook exited with code 1`)
- [ ] After changing hook commands, re-trust Baz hooks in `/hooks`


Made with [Cursor](https://cursor.com)